### PR TITLE
Change Unity plugin to Unity asset phrasing

### DIFF
--- a/build-platform.sh
+++ b/build-platform.sh
@@ -43,7 +43,7 @@ if [ "$TARGET" = "ios" ]; then
     mkdir -p $DEST_IOS_FRAMEWORK_DIR || exit_with_failure "Unable to create iOS framework directory"
     mkdir -p $DEST_IOS_FRAMEWORK_DIR/Xcode11 || exit_with_failure "Unable to create iOS framework directory"
     mkdir -p $DEST_IOS_FRAMEWORK_DIR/Xcode12AndHigher || exit_with_failure "Unable to create iOS framework directory"
-    mkdir -p $DEST_UNITY_IOS_PLUGIN_DIR || exit_with_failure "Unable to create Android Unity plugin directory"
+    mkdir -p $DEST_UNITY_IOS_PLUGIN_DIR || exit_with_failure "Unable to create Android Unity asset directory"
 
     cp -vr $SOURCE_IOS_DEVICE_FRAMEWORK_DIR/ $DEST_IOS_FRAMEWORK_DIR/Xcode11/devices/ || exit_with_failure "Copying iOS devices framework failed"
     cp -vr $SOURCE_IOS_SIMULATOR_FRAMEWORK_DIR/ $DEST_IOS_FRAMEWORK_DIR/Xcode11/simulator/ || exit_with_failure "Copying iOS simulator framework failed"
@@ -62,7 +62,7 @@ elif [ "$TARGET" = "android" ]; then
 
     echo "➡️ Copying build artifacts"
     mkdir -p $DEST_ANDROID_LIBRARY_DIR || exit_with_failure "Unable to create Android library directory"
-    mkdir -p $DEST_UNITY_ANDROID_PLUGIN_DIR || exit_with_failure "Unable to create Android Unity plugin directory"
+    mkdir -p $DEST_UNITY_ANDROID_PLUGIN_DIR || exit_with_failure "Unable to create Android asset directory"
 
     cp -vr $SOURCE_ANDROID_AAR_FILE $DEST_ANDROID_LIBRARY_DIR/LofeltHaptics.aar || exit_with_failure "Copying Android library failed"
     cp -vr $SOURCE_ANDROID_JAVADOC_DIR/ $DEST_ANDROID_LIBRARY_DIR/docs || exit_with_failure "Copying Android API documentation failed"

--- a/core/api/src/jni_api.rs
+++ b/core/api/src/jni_api.rs
@@ -324,7 +324,7 @@ pub fn load_direct_inner(
 // C API for directly loading a clip, bypassing the JNI API
 // `Java_com_lofelt_haptics_LofeltHaptics_load()`.
 //
-// This is called from our Unity plugin when loading a clip. For all other operations
+// This is called from the Unity asset scripts when loading a clip. For all other operations
 // apart from loading a clip, Unity calls into the Java API, which in turn calls the
 // JNI API in this file.
 //

--- a/interfaces/android/LofeltHaptics/LofeltHaptics/consumer-rules.pro
+++ b/interfaces/android/LofeltHaptics/LofeltHaptics/consumer-rules.pro
@@ -9,9 +9,7 @@
 -keep class com.lofelt.haptics.Player { *; }
 
 # Keep the public API of the "LofeltHaptics" and "HapticPatterns" classes. This is needed if the API
-# is used via JNI, like in the C# scripts of the Nice Vibrations Unity plugin. ProGuard/R8 is unable
+# is used via JNI, like in the C# scripts of the Nice Vibrations Unity asset. ProGuard/R8 is unable
 # to detect calls made via JNI.
 -keep class com.lofelt.haptics.LofeltHaptics { *; }
 -keep class com.lofelt.haptics.HapticPatterns { *; }
-
-

--- a/interfaces/android/LofeltHaptics/LofeltHaptics/src/main/java/com/lofelt/haptics/LofeltHaptics.java
+++ b/interfaces/android/LofeltHaptics/LofeltHaptics/src/main/java/com/lofelt/haptics/LofeltHaptics.java
@@ -249,11 +249,11 @@ public class LofeltHaptics {
 
     // Unfortunately javadoc doesn't understand @hide, so this method will appear
     // in the documentation even though we don't want users to use this method.
-    // We only need it here for our Unity plugin.
+    // We only need it here for the Unity asset scripts.
     //
     // @SuppressWarnings("unused") is used to suppress an Android Studio linter warning about
     // this method not being used. While we indeed don't call it from any of the tests, it
-    // is used by our Unity plugin.
+    // is used by the Unity asset scripts.
 
     /**
      * Returns a handle to the controller of the native library.

--- a/interfaces/unity/Mainpage.dox
+++ b/interfaces/unity/Mainpage.dox
@@ -1,6 +1,6 @@
 /*! \mainpage Overview
  *
- * This is the API documentation for Nice Vibrations, a Unity plugin by
+ * This is the API documentation for Nice Vibrations, a Unity asset by
  * <a href="https://lofelt.com/">Lofelt</a> that provides haptic feedback for mobile devices
  * and gamepads.
  *

--- a/interfaces/unity/README.md
+++ b/interfaces/unity/README.md
@@ -12,7 +12,7 @@
 
 # Overview
 
-This folder contains our Unity plugin. It consists of:
+This folder contains the Nice Vibrations Unity asset. It consists of:
 - The plugin script code (in `Assets/NiceVibrations/Scripts/`)
 - The iOS and Android plugins from our Lofelt SDK, which are used by the script
   code (in `Assets/NiceVibrations/Plugins`)

--- a/unity-editor-plugin/README.md
+++ b/unity-editor-plugin/README.md
@@ -13,7 +13,7 @@
 # Background
 
 This folder contains a plugin for the Unity editor, which is used by our Nice Vibrations
-Unity plugin.
+Unity asset.
 
 The plugin converts `.haptic` clips to a structure suitable for playback on gamepads with Unity's
 Gamepad API.


### PR DESCRIPTION
FYI this PR changes some text where the "Unity plugin" phrasing doesn't make sense, and to avoid confusion with "Unity Editor plugin host". Unity asset is the correct way to reference Nice Vibrations.