### PR TITLE
Bump remove_dir_all to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [


### PR DESCRIPTION
# Bump remove_dir_all to 0.8.0

## Type of change 
There is a [security risk](https://github.com/advisories/GHSA-mc8h-8q98-g5hr) on remove_all_dir with versions prior to 0.8.0. This PR bumps the dependency version to 0.8.0.