### PR TITLE
Update android build dependencies

### DIFF
--- a/interfaces/android/LofeltHaptics/LofeltHaptics/build.gradle
+++ b/interfaces/android/LofeltHaptics/LofeltHaptics/build.gradle
@@ -65,8 +65,8 @@ android {
 apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 
 dependencies {
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'junit:junit:4.13.2'
 
     // The version check here is disabled, because it incorrectly warns that a
@@ -75,7 +75,7 @@ dependencies {
     //noinspection GradleDependency
     androidTestImplementation 'commons-io:commons-io:2.11.0'
 
-    implementation 'androidx.annotation:annotation:1.5.0'
+    implementation 'androidx.annotation:annotation:1.6.0'
 }
 
 cargo {


### PR DESCRIPTION
# Update android build dependencies

## Solution Description

The android build was failing due to lint errors. This PR updates the dependencies involved.