### PR TITLE
Update toolchain 1.60 and fix iOS build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,10 +28,10 @@ jobs:
     - name: Install NDK version 21.3.6528147
       run: sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.3.6528147"
 
-    - name: Install Rust 1.56.0 toolchain
+    - name: Install Rust 1.60.0 toolchain
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.56.0
+          toolchain: 1.60.0
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -23,10 +23,10 @@ jobs:
           target
         key: ios-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-v3
 
-    - name: Install Rust 1.56.0 toolchain
+    - name: Install Rust 1.60.0 toolchain
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.56.0
+          toolchain: 1.60.0
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/release-sdk-and-nicevibrations.yml
+++ b/.github/workflows/release-sdk-and-nicevibrations.yml
@@ -78,10 +78,10 @@ jobs:
           brew install rename doxygen graphviz
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
 
-    - name: Install Rust 1.56.0 toolchain
+    - name: Install Rust 1.60.0 toolchain
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.56.0
+          toolchain: 1.60.0
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -29,10 +29,10 @@ jobs:
           target
         key: rust-core-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Install Rust 1.56.0 toolchain
+    - name: Install Rust 1.60.0 toolchain
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.56.0
+          toolchain: 1.60.0
           override: true
           components: rustfmt, clippy
 

--- a/interfaces/ios/LofeltHaptics/LofeltHaptics.xcodeproj/project.pbxproj
+++ b/interfaces/ios/LofeltHaptics/LofeltHaptics.xcodeproj/project.pbxproj
@@ -586,6 +586,7 @@
 				DYLIB_CURRENT_VERSION = 1.3.4;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../../core/api",
 					"$(PROJECT_DIR)/include",
@@ -633,6 +634,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_TESTABILITY = NO;
 				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/include",
 					"$(PROJECT_DIR)/../../../core/api",

--- a/interfaces/ios/README.md
+++ b/interfaces/ios/README.md
@@ -31,7 +31,7 @@ This folder has the iOS Framework project containing source code for the Lofelt 
 
 # Setting up the Development Environment
 
-- ⚠️ Make sure you have set Rust's 1.56 toolchain as the default toolchain. Currently, building for iOS requires Rust 1.56 toolchain.
+- ⚠️ Make sure you have set Rust's 1.60 toolchain as the default toolchain. Currently, building for iOS requires Rust 1.60 toolchain.
 
 - Install cargo-lipo:
 


### PR DESCRIPTION
# Update toolchain 1.60 and fix iOS build

## Solution Description

The iOS build was failing since a dependency requires the 1.60 toolchain. Also the Xcode project requires that the arm64 architecture is excluded from the build when running on the simulator.
With this changes the build is back to green.