### PR TITLE
Fix version number in the exported .ahap files

### DIFF
--- a/core/datamodel/src/ios/v1.rs
+++ b/core/datamodel/src/ios/v1.rs
@@ -39,8 +39,10 @@ impl Ahap {
 
     /// Splits AHAP data into two AHAPs with continuous and transient events respectively
     pub fn into_continuous_and_transients_ahaps(self) -> (Ahap, Option<Ahap>) {
-        let mut ahap_transients = Ahap::default();
-        let mut ahap_continuous = Ahap::default();
+        let ahap_version = 1.0;
+
+        let mut ahap_transients = Ahap { version: ahap_version, ..Default::default() };
+        let mut ahap_continuous = Ahap { version: ahap_version, ..Default::default() };
 
         for pattern in self.pattern {
             match pattern {


### PR DESCRIPTION
# Fix version number in the exported .ahap files

## Solution Description

See #38, the ahap export was creating two ahap files with the version number set to `0.0`.
In this PR we set the version number on both the continuous and transient exports.
